### PR TITLE
Add PowerShell preflight script and VS Code UTF-8 profile

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+  "python.defaultInterpreterPath": "${workspaceFolder}\\.venv\\Scripts\\python.exe",
+  "files.eol": "\r\n",
+  "files.encoding": "utf8",
+  "terminal.integrated.defaultProfile.windows": "PowerShell UTF-8",
+  "terminal.integrated.profiles.windows": {
+    "PowerShell UTF-8": {
+      "source": "PowerShell",
+      "args": [
+        "-NoExit",
+        "-Command",
+        "chcp 65001; [Console]::InputEncoding=[Text.Encoding]::UTF8; [Console]::OutputEncoding=[Text.Encoding]::UTF8"
+      ]
+    }
+  },
+  "terminal.integrated.env.windows": {
+    "PYTHONUTF8": "1"
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,17 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Preflight",
+      "type": "shell",
+      "command": "powershell -ExecutionPolicy Bypass -File scripts\\preflight.ps1",
+      "problemMatcher": []
+    },
+    {
+      "label": "Run CLI REPL",
+      "type": "shell",
+      "command": ".\\.venv\\Scripts\\python.exe ch_repl.py",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/scripts/preflight.ps1
+++ b/scripts/preflight.ps1
@@ -1,0 +1,19 @@
+Param()
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+Write-Host "Preflight starting..."
+
+try { $py = & python --version; Write-Host "Python: $py" }
+catch { Write-Error "Python not found in PATH or venv not activated."; exit 1 }
+
+$envPath = ".env.local"
+if (Test-Path $envPath) { Write-Host ".env.local present" } else { Write-Warning ".env.local missing. Copy .env.example" }
+
+$ollamaHost = $env:OLLAMA_HOST; if (-not $ollamaHost) { $ollamaHost = "http://127.0.0.1:11434" }
+try {
+  $resp = Invoke-WebRequest -Method Get -Uri "$ollamaHost/api/tags" -TimeoutSec 5
+  Write-Host "Ollama reachable. Models:"; ($resp.Content | ConvertFrom-Json).models | ForEach-Object { " - " + $_.name } | Write-Host
+} catch { Write-Warning "Ollama not reachable at $ollamaHost" }
+
+Write-Host "Preflight done."


### PR DESCRIPTION
## Summary
- add Windows-compatible `preflight.ps1` with Python/Env/Ollama checks
- configure VS Code to use UTF-8 PowerShell profile and venv interpreter
- add VS Code tasks for preflight and CLI REPL

## Testing
- `pytest` (no tests ran)


------
https://chatgpt.com/codex/tasks/task_e_689d08156b0c8322a1c115eed68b8573