### PR TITLE
feat(bench): add Fibonacci budget forcing and H-Net DC [3,5] bench

### DIFF
--- a/experiments/hnet_fib/config.yaml
+++ b/experiments/hnet_fib/config.yaml
@@ -1,0 +1,13 @@
+model:
+  dc_factors: [3, 5]
+  widths: [1024, 1659, 2687]
+  ratio_loss_alpha: 0.03
+train:
+  curriculum:
+    - {epochs: 1, dc_factors: [2]}
+    - {epochs: 2, dc_factors: [3]}
+    - {epochs: 2, dc_factors: [3,5]}
+eval:
+  save_dir: runs/hnet_fib
+  report_bpb: true
+  report_bpic: true

--- a/scripts/bench_fib.ps1
+++ b/scripts/bench_fib.ps1
@@ -1,0 +1,16 @@
+param(
+  [int[]] $Budgets = @(512, 832, 1344, 2176, 3520),
+  [string] $EvalSet = "AIME24"
+)
+New-Item -ItemType Directory -Force -Path runs | Out-Null
+$cmd = 'python .\infer_reasoning.py --max-think {budget} --min-think {budget} --force-continue Wait --evalset {eval} --out runs\aime_b{budget}.json'
+$cmd = $cmd -replace '{eval}', $EvalSet
+Write-Host "[bench] budgets: $($Budgets -join ', ')"
+Write-Host "[bench] cmd template: $cmd"
+if ($Budgets.Count -gt 0) {
+  $args = @('--cmd', $cmd, '--budgets') + ($Budgets | ForEach-Object { "$_" }) + @('--out', 'runs\fib_summary.json')
+} else {
+  $args = @('--cmd', $cmd, '--out', 'runs\fib_summary.json')
+}
+python .\tools\bench_fibonacci.py @args
+Write-Host "[bench] done. See runs\fib_summary.json"

--- a/tools/bench_fibonacci.py
+++ b/tools/bench_fibonacci.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+import argparse, json, subprocess
+from pathlib import Path
+from typing import List, Dict, Any
+from budget_forcing import BudgetController
+
+def run_cmd(cmd: str) -> int:
+    print(f"[bench] exec: {cmd}", flush=True)
+    completed = subprocess.run(cmd, shell=True)
+    return completed.returncode
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cmd", required=True,
+                    help="Command template with {budget}. Example: python .\\infer_reasoning.py --max-think {budget} --min-think {budget} --force-continue Wait --evalset AIME24 --out runs\\aime_b{budget}.json")
+    ap.add_argument("--budgets", nargs="*", type=int, default=None)
+    ap.add_argument("--limit", type=int, default=100000)
+    ap.add_argument("--out", default="runs/fib_summary.json")
+    args = ap.parse_args()
+
+    bc = BudgetController(limit=args.limit)
+    budgets = args.budgets or bc.budgets()
+    Path("runs").mkdir(parents=True, exist_ok=True)
+
+    summary: List[Dict[str, Any]] = []
+    for b in budgets:
+        cmd = args.cmd.format(budget=b)
+        rc = run_cmd(cmd)
+        record: Dict[str, Any] = {"budget": b, "returncode": rc}
+        guess = Path(f"runs/aime_b{b}.json")
+        if guess.exists():
+            try:
+                data = json.loads(guess.read_text(encoding="utf-8"))
+                for k in ["control", "scaling", "performance", "accuracy", "loss"]:
+                    if k in data:
+                        record[k] = data[k]
+            except Exception as e:
+                record["ingest_error"] = str(e)
+        summary.append(record)
+
+    Path(args.out).write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    print(f"[bench] wrote {args.out}")
+
+if __name__ == "__main__":
+    main()

--- a/tools/budget_forcing.py
+++ b/tools/budget_forcing.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import List
+
+PHI = 1.618033988749895
+
+def fib_steps(n0: int = 512, n1: int = 832, limit: int = 100000) -> List[int]:
+    a, b = n0, n1
+    steps = [a, b]
+    while True:
+        c = a + b
+        if c > limit:
+            break
+        steps.append(c)
+        a, b = b, c
+    return steps
+
+@dataclass
+class BudgetController:
+    first: int = 512
+    second: int = 832
+    limit: int = 100000
+    continue_token: str = "Wait"
+
+    def budgets(self) -> List[int]:
+        return fib_steps(self.first, self.second, self.limit)
+
+    def force_continue_str(self) -> str:
+        return self.continue_token


### PR DESCRIPTION
## Summary
- add H-Net config with DC [3,5] and phi-scaled widths
- introduce Fibonacci-based budget forcing utilities and bench runner
- provide PowerShell script to execute bench across budgets

## Testing
- `python -m py_compile tools/budget_forcing.py tools/bench_fibonacci.py`
- `python tools/bench_fibonacci.py --cmd "echo budget {budget}" --budgets 1 2 --out runs/test_summary.json`


------
https://chatgpt.com/codex/tasks/task_e_689d0d10b6d883228273ef21e5c432b7