### PR TITLE
Add interactive mission loop with agent stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 +/project/*.cache
 +
 +/.agent_logs/
+
+__pycache__/
+.DS_Store
+docs/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: run ideas docs
+
+run:
+	python3 loop_agent.py
+
+# Auto-approve first mission (demo)
+ideas:
+	echo "y" | python3 loop_agent.py
+
+# Quick doc demo (approve, title, body)
+docs:
+	echo -e "y\ncloudhabil_cli_overview\nThis is an auto-doc.\n" | python3 loop_agent.py

--- a/agents.py
+++ b/agents.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+from datetime import datetime
+
+# Adjust to your repo root if needed:
+REPO_DIR = Path.cwd()
+DOCS_DIR = REPO_DIR / "docs"
+DOCS_DIR.mkdir(exist_ok=True, parents=True)
+
+def agent_generate_ideas(context: dict) -> str:
+    ideas = [
+        "- /agent init <persona>: create scoped expert agents (senior backend, DevOps, product).",
+        "- Self-healing deps: detect CVEs/deprecations and auto-suggest patches.",
+        "- Explain-as-you-code: inline rationale + alternatives while editing.",
+        "- HabilModules: snap-in FastAPI/Flask micro-modules (auth, CRUD, billing).",
+        "- Mission Loop telemetry: measure suggestion acceptance & cycle time."
+    ]
+    return "High-impact ideas:\n" + "\n".join(ideas)
+
+def agent_explain_concepts(topic: str) -> str:
+    return (
+        f"Concept deep-dive on '{topic}':\n"
+        "- What / Why / Trade-offs\n"
+        "- Modern applications\n"
+        "- Example(s) with pros/cons"
+    )
+
+def agent_optimize_code(code: str) -> str:
+    # Placeholder for Codex+linting; return a diff-like suggestion
+    return (
+        "Suggested improvements:\n"
+        "- Extract pure functions\n"
+        "- Add typing\n"
+        "- Reduce nesting\n"
+        "- Use logging over prints"
+    )
+
+def agent_resolve_problems(symptoms: str) -> str:
+    return (
+        "Gold Road (resolution path):\n"
+        "1) Reproduce reliably\n"
+        "2) Minimize test case\n"
+        "3) Inspect logs/metrics\n"
+        "4) Add assertions\n"
+        "5) Patch + verify\n"
+        "6) Regression guard"
+    )
+
+def agent_best_practices(scope: str) -> str:
+    return (
+        f"Best practices for {scope}:\n"
+        "- Clean architecture\n"
+        "- Hexagonal boundaries\n"
+        "- Observability first\n"
+        "- CI as code\n"
+        "- Security by default"
+    )
+
+def agent_write_docs(title: str, body: str) -> Path:
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    path = DOCS_DIR / f"{ts}_{title.replace(' ', '_').lower()}.md"
+    path.write_text(f"# {title}\n\n{body}\n", encoding="utf-8")
+    return path
+
+def agent_code_review(code: str) -> str:
+    return (
+        "Code Review:\n"
+        "- Naming clarity\n"
+        "- Single responsibility\n"
+        "- Error handling\n"
+        "- Test coverage\n"
+        "- Performance hotspots"
+    )
+
+def agent_prototype(description: str) -> str:
+    return f'''# prototype_app.py
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+# TODO: {description}
+'''

--- a/config/instructions.json
+++ b/config/instructions.json
@@ -1,0 +1,15 @@
+{
+  "mode": "interactive",
+  "instruction_set": [
+    "Generate ideas: Review ongoing and planned projects, suggest high-impact features or creative approaches with strong future potential.",
+    "Explain concepts: When encountering unfamiliar technical concepts, provide clear, holistic explanations with examples and related context.",
+    "Optimize code: When detecting code snippets, suggest efficiency and readability improvements, initiating a structured debugging process using Codex.",
+    "Resolve problems: Upon finding bugs or complex logic, identify possible solutions and propose an optimal 'gold path' to achieve the objective.",
+    "Learn best practices: Teach cutting-edge principles of design, architectural patterns, and coding standards to elevate skills to industry-leading levels.",
+    "Write documentation: Create and maintain technical documentation, from function-level descriptions to developer guides, ready for upload to the Cloudhabil/CLI repository.",
+    "Simulate code review: Use agents or the custom CLI program to conduct deep AI-assisted code reviews, offering actionable recommendations and performing advanced debugging.",
+    "Rapidly prototype ideas: For simple functional requests, build a minimal working snippet or prototype, refining iteratively until a complete functional app.py is achieved."
+  ],
+  "loop_mode": "sequential",
+  "loop_condition": "If one mission is finished, proceed immediately to the next mission."
+}

--- a/loop_agent.py
+++ b/loop_agent.py
@@ -1,0 +1,93 @@
+import json
+import sys
+from pathlib import Path
+from agents import (
+    agent_generate_ideas, agent_explain_concepts, agent_optimize_code,
+    agent_resolve_problems, agent_best_practices, agent_write_docs,
+    agent_code_review, agent_prototype
+)
+
+CONFIG_PATH = Path("config/instructions.json")
+
+def load_config():
+    if not CONFIG_PATH.exists():
+        print(f"Config not found: {CONFIG_PATH}")
+        sys.exit(1)
+    return json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+
+def prompt_yes_no(msg: str) -> bool:
+    try:
+        ans = input(f"{msg} (y/n): ").strip().lower()
+        return ans == "y"
+    except EOFError:
+        return False
+
+def run_interactive(instruction_set):
+    idx = 0
+    while True:
+        task = instruction_set[idx]
+        print(f"\n🟢 Next mission [{idx+1}/{len(instruction_set)}]: {task}")
+        if not prompt_yes_no("Approve this mission?"):
+            print("⏭️  Skipped.")
+        else:
+            dispatch(task)
+            print("✅ Mission completed.")
+        idx = (idx + 1) % len(instruction_set)
+
+def dispatch(task: str):
+    title = task.split(":")[0].strip().lower()
+
+    if title.startswith("generate ideas"):
+        print(agent_generate_ideas(context={}))
+    elif title.startswith("explain concepts"):
+        topic = input("Concept to explain (free text): ").strip() or "architecture layering"
+        print(agent_explain_concepts(topic))
+    elif title.startswith("optimize code"):
+        print("Paste code below. End with a single line containing only 'EOF'.")
+        code = read_block_until_eof()
+        print(agent_optimize_code(code))
+    elif title.startswith("resolve problems"):
+        symptoms = input("Describe bug/logic symptoms: ").strip()
+        print(agent_resolve_problems(symptoms))
+    elif title.startswith("learn best practices"):
+        scope = input("Area (e.g., backend, DevOps, data): ").strip() or "backend"
+        print(agent_best_practices(scope))
+    elif title.startswith("write documentation"):
+        doc_title = input("Doc title: ").strip() or "cloudhabil_cli_notes"
+        body = input("Doc body (short ok): ").strip() or "Auto-generated notes."
+        path = agent_write_docs(doc_title, body)
+        print(f"📝 Documentation saved to: {path}")
+    elif title.startswith("simulate code review"):
+        print("Paste code for review. End with 'EOF'.")
+        code = read_block_until_eof()
+        print(agent_code_review(code))
+    elif title.startswith("rapidly prototype ideas"):
+        desc = input("Prototype description (what should it do?): ").strip() or "health endpoint + TODO marker"
+        print(agent_prototype(desc))
+    else:
+        print("⚠️ Unrecognized mission; no-op.")
+
+def read_block_until_eof() -> str:
+    lines = []
+    while True:
+        line = sys.stdin.readline()
+        if not line:
+            break
+        if line.strip() == "EOF":
+            break
+        lines.append(line)
+    return "".join(lines)
+
+def main():
+    cfg = load_config()
+    mode = cfg.get("mode", "interactive")
+    instruction_set = cfg.get("instruction_set", [])
+    if not instruction_set:
+        print("No instructions found.")
+        sys.exit(1)
+    if mode != "interactive":
+        print(f"Mode '{mode}' not supported in this script. Forcing interactive.")
+    run_interactive(instruction_set)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- ignore build artifacts and docs in `.gitignore`
- add Makefile targets for running interactive agent loop and demos
- introduce agent stubs for ideation, explanations, optimization, docs, reviews, and prototypes
- provide interactive loop driver using configurable instruction set

## Testing
- `python -m py_compile agents.py loop_agent.py`
- `python3 loop_agent.py` *(manual KeyboardInterrupt after skipping a mission)*

------
https://chatgpt.com/codex/tasks/task_e_68a0634712348322998a14fc3b33e574