### PR TITLE
feat(bench): Fibonacci compute budgets and sesamawake runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,10 @@ project/*.cache
 .agent_logs/
 __pycache__/
 .DS_Store
-docs/
 logs/
 data/
 reports/
 .idea/
 .vscode/
 .pytest_cache/
+runs/

--- a/docs/mission_fib_hnet.md
+++ b/docs/mission_fib_hnet.md
@@ -1,0 +1,20 @@
+# Mission: Fibonacci bench and H-Net DC [3,5]
+Run:
+```
+pwsh -File .\scripts\sesamawake.ps1
+```
+Outputs:
+- `runs/aime_b{budget}.json` when inference writes metrics
+- `runs/fib_summary.json` aggregate
+
+Backlog next missions:
+1) Tokenization-free polyglot reasoning
+2) Adaptive pay-for-thought API
+3) Private on-device copilot on NPU
+4) Million-token effective context
+5) Compression-first RAG index
+6) Streaming multimodal agent
+7) Curriculum with Fibonacci DC
+8) Governance via compute caps
+9) Scaling-laws bench product
+10) Knowledge-compression adapters

--- a/scripts/sesamawake.ps1
+++ b/scripts/sesamawake.ps1
@@ -1,0 +1,30 @@
+param(
+  [int[]] $Budgets = @(512, 832, 1344, 2176, 3520),
+  [string] $EvalSet = "AIME24"
+)
+
+# Optional venv activation if present
+$venv = ".\.venv\Scripts\Activate.ps1"
+if (Test-Path $venv) { . $venv }
+
+New-Item -ItemType Directory -Force -Path runs | Out-Null
+
+# Adjust this to your real inference entrypoint if different
+$cmd = 'python .\infer_reasoning.py --max-think {budget} --min-think {budget} --force-continue Wait --evalset {eval} --out runs\aime_b{budget}.json'
+$cmd = $cmd -replace '{eval}', $EvalSet
+
+Write-Host "[sesamawake] budgets: $($Budgets -join ', ')"
+Write-Host "[sesamawake] template: $cmd"
+
+if ($Budgets.Count -gt 0) {
+  $args = @('--cmd', $cmd, '--budgets') + ($Budgets | ForEach-Object { "$_" }) + @('--out', 'runs\fib_summary.json')
+} else {
+  $args = @('--cmd', $cmd, '--out', 'runs\fib_summary.json')
+}
+python .\tools\bench_fibonacci.py @args
+
+if (Test-Path 'runs\fib_summary.json') {
+  Write-Host "[sesamawake] OK -> runs\fib_summary.json"
+} else {
+  Write-Host "[sesamawake] finished with no summary file"
+}


### PR DESCRIPTION
## Summary
- add Windows `sesamawake` script to sweep inference over Fibonacci budgets
- document mission and backlog for H-Net DC [3,5]
- ignore run artifacts via `.gitignore`

## Testing
- `pwsh -File scripts/sesamawake.ps1` *(fails: pwsh not installed)*
- `python tools/bench_fibonacci.py --cmd "python ./infer_reasoning.py --max-think {budget} --min-think {budget} --force-continue Wait --evalset AIME24 --out runs/aime_b{budget}.json" --budgets 512 832 --out runs/fib_summary.json`


------
https://chatgpt.com/codex/tasks/task_e_68a073f63f8c8322b1bef6646ce7059f