### PR TITLE
feat: add chat client interface with openai backend

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,26 @@
+# Configuration
+
+Model backends are defined in `configs/models.yaml`.
+Each model entry supports the following fields:
+
+- `kind` – backend type. Supported values are `ollama` and `openai`.
+- `endpoint` – HTTP endpoint for the chat API.
+- `model` – identifier of the model to use.
+
+For the `openai` backend an API key must be supplied via the `OPENAI_API_KEY`
+environment variable. The default endpoint for OpenAI is
+`https://api.openai.com/v1/chat/completions`.
+
+Example configuration:
+
+```yaml
+models:
+  local_llm:
+    kind: ollama
+    endpoint: http://127.0.0.1:11434/api/chat
+    model: llama3.1:latest
+  gpt4o:
+    kind: openai
+    endpoint: https://api.openai.com/v1/chat/completions
+    model: gpt-4o-mini
+```

--- a/models/backend.py
+++ b/models/backend.py
@@ -1,8 +1,19 @@
+import os
+from abc import ABC, abstractmethod
+from typing import List, Dict
+
 import requests
-from typing import List, Dict, Any
 
 
-class OllamaChat:
+class BaseChatClient(ABC):
+    """Minimal interface for chat model backends."""
+
+    @abstractmethod
+    def chat(self, messages: List[Dict[str, str]]) -> str:
+        """Send chat messages and return the model response."""
+
+
+class OllamaChat(BaseChatClient):
     def __init__(self, endpoint: str, model: str):
         self.endpoint = endpoint
         self.model = model
@@ -17,7 +28,33 @@ class OllamaChat:
         return ""
 
 
+class OpenAIChat(BaseChatClient):
+    def __init__(self, endpoint: str, model: str, api_key: str | None = None):
+        self.endpoint = endpoint or "https://api.openai.com/v1/chat/completions"
+        self.model = model
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY", "")
+        if not self.api_key:
+            raise ValueError("OpenAI API key not provided")
+
+    def chat(self, messages: List[Dict[str, str]]) -> str:
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        payload = {"model": self.model, "messages": messages}
+        r = requests.post(self.endpoint, headers=headers, json=payload, timeout=120)
+        r.raise_for_status()
+        data = r.json()
+        return (
+            data.get("choices", [{}])[0]
+            .get("message", {})
+            .get("content", "")
+        )
+
+
 def make_client(kind: str, endpoint: str, model: str):
     if kind == "ollama":
         return OllamaChat(endpoint, model)
+    if kind == "openai":
+        return OpenAIChat(endpoint, model)
     raise ValueError(f"unknown model backend {kind}")


### PR DESCRIPTION
## Summary
- define `BaseChatClient` interface for chat models
- support OpenAI chat completions via `OpenAIChat`
- document model configuration options

## Testing
- `python -m py_compile models/backend.py`


------
https://chatgpt.com/codex/tasks/task_e_68a077beddb88322b7eb1001f3eeab86