### PR TITLE
feat(ui): add profile settings and i18n support

### DIFF
--- a/admin_tui.py
+++ b/admin_tui.py
@@ -1,13 +1,15 @@
 from typing import Callable
 from rich.console import Console
 from kb import last, search, add_entry
+from ui.i18n import load_strings
 
 
 def main(route: Callable[[str, str, str], None], check_ceo: Callable[[str], str]):
     console = Console()
+    strings = load_strings()
     while True:
         try:
-            line = console.input("admin> ")
+            line = console.input(strings.get("prompt", "admin> "))
         except (EOFError, KeyboardInterrupt):
             break
         if not line.strip():
@@ -36,4 +38,4 @@ def main(route: Callable[[str, str, str], None], check_ceo: Callable[[str], str]
             topic, text = rest.split("||", 1)
             add_entry(kind="memo", topic=topic.strip(), text=text.strip())
         else:
-            console.print("unknown command")
+            console.print(strings.get("unknown_command", "unknown command"))

--- a/app_templates/app.py.j2
+++ b/app_templates/app.py.j2
@@ -6,8 +6,10 @@ from __future__ import annotations
 import sys, json, pathlib, time
 import typer
 from rich import print
+from ui.i18n import load_strings
 
 app = typer.Typer(add_completion=False)
+strings = load_strings()
 
 @app.command()
 def plan():
@@ -16,14 +18,14 @@ def plan():
     E_s -> Chunk -> M -> Dechunk -> D_s
     """
     stages = ["E_s","Chunk","M","Dechunk","D_s"]
-    print({"pipeline": stages, "note":"placeholder"})
+    print({"pipeline": stages, "note": strings.get("plan_note", "placeholder")})
 
 @app.command()
 def run():
     """
     Execute the current plan stub. Replace with real actions as the agent evolves.
     """
-    print("Running plan stub... ok")
+    print(strings.get("run_stub", "Running plan stub... ok"))
 
 @app.command()
 def debug():

--- a/config/ui_options.yaml
+++ b/config/ui_options.yaml
@@ -1,0 +1,7 @@
+types:
+  - pixel
+  - free
+  - preset
+languages:
+  - en
+  - es

--- a/locales/en.yaml
+++ b/locales/en.yaml
@@ -1,0 +1,4 @@
+prompt: "admin> "
+unknown_command: "unknown command"
+plan_note: "placeholder"
+run_stub: "Running plan stub... ok"

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -1,0 +1,4 @@
+prompt: "admin> "
+unknown_command: "comando desconocido"
+plan_note: "marcador de posición"
+run_stub: "Ejecutando plan stub... ok"

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -43,6 +43,12 @@ def spawn_stripe():
     _wait_health("http://127.0.0.1:7077/health")
 
 
+def spawn_profile():
+    p = subprocess.Popen(["python", "profile_server.py"])
+    processes.append(p)
+    _wait_health("http://127.0.0.1:7099/health")
+
+
 def spawn_agent(role: str, info: dict):
     model_cfg = CONFIG_MODELS["models"][info["model"]]
     env = os.environ.copy()
@@ -92,6 +98,7 @@ def check_ceo(decision_summary: str):
 def boot():
     spawn_bus()
     spawn_stripe()
+    spawn_profile()
     for role in CONFIG_AGENTS["admin"]["wake_order"]:
         spawn_agent(role, CONFIG_AGENTS["agents"][role])
     while True:

--- a/profile_server.py
+++ b/profile_server.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import os
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import yaml
+
+app = FastAPI()
+CONFIG = yaml.safe_load(open("config/ui_options.yaml"))
+PROFILE_DIR = Path("profiles")
+PROFILE_DIR.mkdir(exist_ok=True)
+
+class Settings(BaseModel):
+    ui_type: str
+    lang: str
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+@app.patch("/profile/{user_id}/settings")
+async def update_settings(user_id: str, settings: Settings):
+    if settings.ui_type not in CONFIG.get("types", []):
+        raise HTTPException(status_code=400, detail="invalid ui_type")
+    if settings.lang not in CONFIG.get("languages", []):
+        raise HTTPException(status_code=400, detail="unsupported language")
+    with open(PROFILE_DIR / f"{user_id}.yaml", "w", encoding="utf-8") as f:
+        yaml.safe_dump(settings.dict(), f)
+    return {"status": "ok"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+    port = int(os.environ.get("PORT", 7099))
+    uvicorn.run("profile_server:app", host="0.0.0.0", port=port)

--- a/ui/i18n.py
+++ b/ui/i18n.py
@@ -1,0 +1,17 @@
+import os
+from pathlib import Path
+import yaml
+
+_LOCALE_CACHE = {}
+
+def load_strings(lang: str | None = None) -> dict:
+    """Load UI strings for the given language from locales/<lang>.yaml.
+
+    Caches loaded locales to avoid repeated disk reads.
+    """
+    lang = lang or os.environ.get("UI_LANG", "en")
+    if lang not in _LOCALE_CACHE:
+        loc_file = Path(__file__).resolve().parent.parent / "locales" / f"{lang}.yaml"
+        with open(loc_file, "r", encoding="utf-8") as f:
+            _LOCALE_CACHE[lang] = yaml.safe_load(f) or {}
+    return _LOCALE_CACHE[lang]


### PR DESCRIPTION
## Summary
- add configurable UI options with supported types and languages
- persist user preferences via new `/profile/{user_id}/settings` endpoint
- load translated strings from `locales/{lang}.yaml` across UI modules

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a09037dc988322aacb4f5584b151ac