### PR TITLE
feat: add minimal workspace UI

### DIFF
--- a/orchestrator.py
+++ b/orchestrator.py
@@ -99,10 +99,17 @@ def boot():
 
 
 @app.command()
-def shell():
-    from admin_tui import main as tui_main
+def shell(
+    minimal: bool = typer.Option(
+        False, "--minimal", help="Launch minimal workspace interface"
+    )
+):
+    if minimal:
+        from ui.workspace_minimal import main as ui_main
+    else:
+        from admin_tui import main as ui_main
 
-    tui_main(route, check_ceo)
+    ui_main(route, check_ceo)
 
 
 if __name__ == "__main__":

--- a/ui/workspace_minimal.py
+++ b/ui/workspace_minimal.py
@@ -1,0 +1,40 @@
+from typing import Callable
+from rich.console import Console
+from ui_texts import load_texts
+
+
+def main(
+    route: Callable[[str, str, str], None],
+    check_ceo: Callable[[str], str],
+    lang: str = "en",
+) -> None:
+    """Minimal interactive workspace.
+
+    Supports only basic actions: chatting with agents and checking the CEO
+    decision policy. This is a lean alternative to the full admin TUI.
+    """
+    texts = load_texts(lang)
+    console = Console()
+
+    while True:
+        try:
+            line = console.input(texts.get("prompt", "admin> "))
+        except (EOFError, KeyboardInterrupt):
+            break
+        if not line.strip():
+            continue
+
+        if line.startswith("chat "):
+            # Format: chat agent::message
+            _, rest = line.split(" ", 1)
+            agent, msg = rest.split("::", 1)
+            route("admin", agent.strip(), msg.strip())
+        elif line.startswith("check "):
+            # Format: check CEO::summary
+            _, rest = line.split(" ", 1)
+            agent, msg = rest.split("::", 1)
+            if agent.strip().upper() == "CEO":
+                verdict = check_ceo(msg.strip())
+                console.print(f"{texts.get('policy', 'policy')}: {verdict}")
+        else:
+            console.print(texts.get("unknown_command", "unknown command"))


### PR DESCRIPTION
## Summary
- implement minimal workspace UI with chat and CEO policy check
- add `--minimal` option to `orchestrator.py shell` to use this interface

## Testing
- `python -m py_compile orchestrator.py ui/workspace_minimal.py ui/__init__.py`
- `python orchestrator.py shell --help` *(fails: yaml.scanner.ScannerError: mapping values are not allowed in configs/agents.yaml line 14)*

------
https://chatgpt.com/codex/tasks/task_e_68a097c713008322ac7c37c7c04f979e