### PR TITLE
Add pixel avatar editor and API

### DIFF
--- a/agent_server.py
+++ b/agent_server.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel
 from typing import Any, List, Dict, Optional
 import yaml
+import json
 
 from models.backend import make_client
 from kb import add_entry
@@ -41,6 +42,11 @@ class SettingsRequest(BaseModel):
 
 class LayoutRequest(BaseModel):
     layout: Optional[Dict[str, Any]] = None
+
+
+class PixelAvatarRequest(BaseModel):
+    palette: List[str]
+    pixels: List[List[int]]
 
 
 @app.on_event("startup")
@@ -110,6 +116,16 @@ async def update_layout(user_id: str, req: LayoutRequest):
     with open(path, "w", encoding="utf-8") as f:
         yaml.safe_dump(req.layout, f)
     return {"status": "saved", "user_id": user_id, "layout": req.layout}
+
+
+@app.post("/profile/{user_id}/avatar/pixel")
+async def save_pixel_avatar(user_id: str, req: PixelAvatarRequest):
+    base = Path("profile/avatars")
+    base.mkdir(parents=True, exist_ok=True)
+    path = base / f"{user_id}.json"
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(req.dict(), f)
+    return {"status": "saved", "user_id": user_id}
 
 
 if __name__ == "__main__":

--- a/orchestrator.py
+++ b/orchestrator.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from admin_policy import evaluate_ceo_decision
 
 app = typer.Typer()
+profile_app = typer.Typer()
+app.add_typer(profile_app, name="profile")
 ROOT = Path(__file__).parent
 CONFIG_AGENTS = yaml.safe_load(open(ROOT / "configs" / "agents.yaml"))
 CONFIG_MODELS = yaml.safe_load(open(ROOT / "configs" / "models.yaml"))
@@ -110,6 +112,14 @@ def shell(
         from admin_tui import main as ui_main
 
     ui_main(route, check_ceo)
+
+
+@profile_app.command("pixel-edit")
+def pixel_edit(user_id: str, size: int = 32):
+    """Open pixel avatar editor for the given user."""
+    from ui.pixel_avatar import edit_avatar
+
+    edit_avatar(user_id, size)
 
 
 if __name__ == "__main__":

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,1 +1,2 @@
 from .free_canvas import FreeCanvas
+from .pixel_avatar import PixelAvatarEditor, edit_avatar

--- a/ui/pixel_avatar.py
+++ b/ui/pixel_avatar.py
@@ -1,0 +1,95 @@
+import json
+from pathlib import Path
+import tkinter as tk
+from typing import List
+
+
+class PixelAvatarEditor(tk.Tk):
+    """Simple pixel editor with configurable grid and basic palette."""
+
+    def __init__(self, user_id: str, size: int = 32, pixel_size: int = 16) -> None:
+        super().__init__()
+        self.title(f"Pixel Avatar - {user_id}")
+        self.user_id = user_id
+        self.size = size
+        self.pixel_size = pixel_size
+        self.palette = [
+            "#000000",
+            "#ffffff",
+            "#ff0000",
+            "#00ff00",
+            "#0000ff",
+            "#ffff00",
+            "#00ffff",
+            "#ff00ff",
+        ]
+        self.selected = 0
+        self.pixels = self._load_pixels()
+        self.rects = [[0] * size for _ in range(size)]
+
+        self.canvas = tk.Canvas(
+            self, width=size * pixel_size, height=size * pixel_size, bg="white"
+        )
+        self.canvas.grid(row=0, column=0, columnspan=len(self.palette))
+        for y in range(size):
+            for x in range(size):
+                x0 = x * pixel_size
+                y0 = y * pixel_size
+                rect_id = self.canvas.create_rectangle(
+                    x0,
+                    y0,
+                    x0 + pixel_size,
+                    y0 + pixel_size,
+                    outline="gray",
+                    fill=self.palette[self.pixels[y][x]],
+                )
+                self.canvas.tag_bind(
+                    rect_id, "<Button-1>", lambda e, x=x, y=y: self._paint(x, y)
+                )
+                self.rects[y][x] = rect_id
+
+        palette_frame = tk.Frame(self)
+        palette_frame.grid(row=1, column=0, columnspan=len(self.palette))
+        for idx, color in enumerate(self.palette):
+            tk.Button(
+                palette_frame,
+                bg=color,
+                width=2,
+                command=lambda i=idx: self._set_color(i),
+            ).grid(row=0, column=idx)
+
+        tk.Button(self, text="Save", command=self._save).grid(
+            row=2, column=0, columnspan=len(self.palette)
+        )
+
+    def _load_pixels(self) -> List[List[int]]:
+        path = Path("profile/avatars") / f"{self.user_id}.json"
+        if path.exists():
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                    return data.get(
+                        "pixels", [[0 for _ in range(self.size)] for _ in range(self.size)]
+                    )
+            except Exception:
+                pass
+        return [[0 for _ in range(self.size)] for _ in range(self.size)]
+
+    def _set_color(self, idx: int) -> None:
+        self.selected = idx
+
+    def _paint(self, x: int, y: int) -> None:
+        self.pixels[y][x] = self.selected
+        self.canvas.itemconfig(self.rects[y][x], fill=self.palette[self.selected])
+
+    def _save(self) -> None:
+        base = Path("profile/avatars")
+        base.mkdir(parents=True, exist_ok=True)
+        path = base / f"{self.user_id}.json"
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump({"palette": self.palette, "pixels": self.pixels}, f)
+
+
+def edit_avatar(user_id: str, size: int = 32) -> None:
+    editor = PixelAvatarEditor(user_id, size)
+    editor.mainloop()


### PR DESCRIPTION
## Summary
- add Tkinter-based pixel avatar editor with configurable grid and palette
- persist avatars to `profile/avatars/{user_id}.json` via new API endpoint
- expose `profile pixel-edit` orchestrator command to launch editor

## Testing
- `python -m py_compile ui/pixel_avatar.py ui/__init__.py agent_server.py orchestrator.py`


------
https://chatgpt.com/codex/tasks/task_e_68a099cad2788322a4159a041c165481