### PR TITLE
Add points system, social hooks, and leaderboard endpoint

### DIFF
--- a/integrations/social_hooks.py
+++ b/integrations/social_hooks.py
@@ -1,0 +1,45 @@
+"""Utilities for notifying external social platforms via webhooks or scheduled jobs."""
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import Any, Dict
+
+import httpx
+from apscheduler.schedulers.background import BackgroundScheduler
+
+scheduler = BackgroundScheduler()
+
+
+def _post(url: str | None, payload: Dict[str, Any]) -> None:
+    """Send *payload* to *url* if defined, ignoring network errors."""
+    if not url:
+        return
+    try:
+        httpx.post(url, json=payload, timeout=10)
+    except Exception:
+        pass
+
+
+def instagram_webhook(event: str, data: Dict[str, Any] | None = None) -> None:
+    payload = {"event": event, "data": data or {}, "ts": datetime.utcnow().isoformat()}
+    _post(os.getenv("INSTAGRAM_WEBHOOK_URL"), payload)
+
+
+def youtube_webhook(event: str, data: Dict[str, Any] | None = None) -> None:
+    payload = {"event": event, "data": data or {}, "ts": datetime.utcnow().isoformat()}
+    _post(os.getenv("YOUTUBE_WEBHOOK_URL"), payload)
+
+
+def discord_webhook(event: str, data: Dict[str, Any] | None = None) -> None:
+    payload = {"event": event, "data": data or {}, "ts": datetime.utcnow().isoformat()}
+    _post(os.getenv("DISCORD_WEBHOOK_URL"), payload)
+
+
+def init_cron() -> None:
+    """Start background scheduler with periodic social webhooks."""
+    if not scheduler.running:
+        scheduler.start()
+    scheduler.add_job(lambda: instagram_webhook("cron"), "cron", minute=0)
+    scheduler.add_job(lambda: youtube_webhook("cron"), "cron", minute=20)
+    scheduler.add_job(lambda: discord_webhook("cron"), "cron", minute=40)

--- a/profile/points.py
+++ b/profile/points.py
@@ -1,0 +1,48 @@
+"""Utility functions for managing user points and rankings."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+# File where points are persisted
+POINTS_FILE = Path("profile/points.json")
+
+# Mapping of reasons to point values
+POINT_VALUES: Dict[str, int] = {
+    "chat": 1,
+    "referral": 5,
+    "contribution": 10,
+}
+
+def _load_points() -> Dict[str, int]:
+    """Load existing point totals from disk."""
+    if POINTS_FILE.exists():
+        with POINTS_FILE.open("r", encoding="utf-8") as fh:
+            try:
+                return json.load(fh)
+            except json.JSONDecodeError:
+                return {}
+    return {}
+
+def _save_points(data: Dict[str, int]) -> None:
+    """Persist point totals to disk."""
+    POINTS_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with POINTS_FILE.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh)
+
+def award_points(user_id: str, reason: str) -> int:
+    """Award points to *user_id* for *reason*.
+
+    Returns the user's new total.
+    """
+    data = _load_points()
+    delta = POINT_VALUES.get(reason, 0)
+    data[user_id] = data.get(user_id, 0) + delta
+    _save_points(data)
+    return data[user_id]
+
+def get_rankings() -> List[Tuple[str, int]]:
+    """Return a list of (user_id, points) sorted by points descending."""
+    data = _load_points()
+    return sorted(data.items(), key=lambda kv: kv[1], reverse=True)


### PR DESCRIPTION
## Summary
- track user points and rankings
- connect social platform webhooks and periodic cron
- expose `/leaderboard` endpoint and award points on chat

## Testing
- `python -m py_compile profile/points.py integrations/social_hooks.py agent_server.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a09cec00708322bc326b0f794af1bb