### PR TITLE
Add unit tests and CI workflow

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+extend-ignore = E203,E266,E402,E501,W503,F401,F841

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  lint-type-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install --upgrade pip
+      - run: pip install -r requirements.txt
+      - run: pip install flake8 mypy pytest
+      - run: flake8 bus_server.py kb.py agent_server.py tests
+      - run: mypy bus_server.py kb.py agent_server.py tests
+      - run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 .DS_Store
 logs/
 data/
+!tests/data/
 reports/
 .idea/
 .vscode/

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+[mypy]
+ignore_missing_imports = True
+disable_error_code = import-untyped

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = -q
+pythonpath = .
+testpaths = tests

--- a/tests/data/bus_messages.json
+++ b/tests/data/bus_messages.json
@@ -1,0 +1,4 @@
+[
+  {"topic": "alpha", "data": {"text": "ping"}},
+  {"topic": "beta", "data": {"text": "pong"}}
+]

--- a/tests/data/kb_entries.json
+++ b/tests/data/kb_entries.json
@@ -1,0 +1,4 @@
+[
+  {"kind": "note", "text": "hello"},
+  {"kind": "bus_message", "text": "world"}
+]

--- a/tests/test_agent_server.py
+++ b/tests/test_agent_server.py
@@ -1,0 +1,80 @@
+import sys
+import types
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+# Provide minimal social_hooks before importing agent_server
+dummy_hooks = types.ModuleType("integrations.social_hooks")
+
+
+def init_cron():
+    pass
+
+
+dummy_hooks.init_cron = init_cron  # type: ignore[attr-defined]
+sys.modules["integrations.social_hooks"] = dummy_hooks
+
+# Stub profile modules required by agent_server
+profile_pkg = types.ModuleType("profile")
+points_mod = types.ModuleType("profile.points")
+badges_mod = types.ModuleType("profile.badges")
+
+
+def award_points(user_id: str, reason: str) -> int:  # noqa: D401 - simple stub
+    return 0
+
+
+def get_rankings():  # noqa: D401 - simple stub
+    return []
+
+
+def assign_badge(user_id: str, badge_id: str | None, frame_id: str | None):  # noqa: D401
+    return {}
+
+
+points_mod.award_points = award_points  # type: ignore[attr-defined]
+points_mod.get_rankings = get_rankings  # type: ignore[attr-defined]
+badges_mod.assign_badge = assign_badge  # type: ignore[attr-defined]
+
+sys.modules["profile"] = profile_pkg
+sys.modules["profile.points"] = points_mod
+sys.modules["profile.badges"] = badges_mod
+
+import agent_server
+
+
+class DummyClient:
+    def chat(self, messages):
+        return "pong"
+
+
+class DummySubscriber:
+    def __init__(self):
+        self.sent = []
+
+    async def publish(self, topic, data):
+        self.sent.append((topic, data))
+
+
+def test_chat_and_publish(monkeypatch):
+    monkeypatch.setattr(agent_server, "client", DummyClient())
+    dummy_sub = DummySubscriber()
+    monkeypatch.setattr(agent_server, "subscriber", dummy_sub)
+    recorded = []
+
+    def fake_add_entry(**kw):
+        recorded.append(kw)
+
+    monkeypatch.setattr(agent_server, "add_entry", fake_add_entry)
+
+    client = TestClient(agent_server.app)
+    r = client.post("/chat", json={"sender": "user", "message": "hi"})
+    assert r.status_code == 200
+    assert r.json()["reply"] == "pong"
+    r = client.post("/publish", json={"sender": "user", "message": "hello"})
+    assert r.status_code == 200
+    assert dummy_sub.sent == [(agent_server.role, "hello")]
+    kinds = {e["kind"] for e in recorded}
+    assert {"chat", "publish"}.issubset(kinds)

--- a/tests/test_bus_server.py
+++ b/tests/test_bus_server.py
@@ -1,0 +1,24 @@
+import json
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+import bus_server
+
+
+def test_publish_and_get(monkeypatch):
+    recorded = []
+
+    def fake_add_entry(**kw):
+        recorded.append(kw)
+
+    monkeypatch.setattr(bus_server, "add_entry", fake_add_entry)
+
+    client = TestClient(bus_server.app)
+    msg = json.loads((Path(__file__).parent / "data" / "bus_messages.json").read_text())[0]
+    r = client.post("/publish", json=msg)
+    assert r.status_code == 200
+    r = client.get("/get", params={"topic": msg["topic"]})
+    assert r.status_code == 200
+    assert r.json() == msg["data"]
+    assert recorded and recorded[0]["kind"] == "bus_message"

--- a/tests/test_kb.py
+++ b/tests/test_kb.py
@@ -1,0 +1,19 @@
+import json
+from pathlib import Path
+
+import kb
+
+
+def test_kb_operations(tmp_path):
+    data_file = Path(__file__).parent / "data" / "kb_entries.json"
+    entries = json.loads(data_file.read_text())
+    kb.DB_PATH = tmp_path / "kb.db"
+    for entry in entries:
+        kb.add_entry(**entry)
+    last_entries = kb.last(2)
+    assert len(last_entries) == 2
+    search_entries = kb.search("hello")
+    assert any("hello" in r["data"] for r in search_entries)
+    first_id = last_entries[0]["id"]
+    entry = kb.get(first_id)
+    assert entry["id"] == first_id


### PR DESCRIPTION
## Summary
- configure pytest and mypy for local testing
- add unit tests for kb, bus server, and agent server with sample data
- run lint, type-check, and tests via GitHub Actions

## Testing
- `flake8 bus_server.py kb.py agent_server.py tests -v`
- `mypy --install-types --non-interactive bus_server.py kb.py agent_server.py tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0a7ee922c83229822190467b55397