### PR TITLE
feat: secure agent server with shared secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,4 @@ GITHUB_REPO=Cloudhabil/CLI
 DEFAULT_BRANCH=main
 GIT_AUTHOR_NAME=Cloudhabil Bot
 GIT_AUTHOR_EMAIL=bot@cloudhabil.local
+AGENT_SERVER_SECRET=

--- a/sesamawake.ps1
+++ b/sesamawake.ps1
@@ -7,6 +7,7 @@ if (!(Test-Path $venv)) { python -m venv $venv }
 pip install -r requirements.txt
 if (!(Test-Path '.env.local')) { Copy-Item '.env.example' '.env.local' }
 $env:PYTHONPATH = $root
+$env:AGENT_SERVER_SECRET = $env:AGENT_SERVER_SECRET
 if (!(Test-Path 'data/google/token.json')) { powershell -ExecutionPolicy Bypass -File scripts/google_auth.ps1 }
 Start-Process -FilePath python -ArgumentList 'orchestrator.py','boot'
 if (-not $NoTUI) { python orchestrator.py shell }

--- a/sesamawake.sh
+++ b/sesamawake.sh
@@ -7,7 +7,7 @@ source .venv/bin/activate
 pip install -r requirements.txt
 [ -f .env.local ] || cp .env.example .env.local
 PYTHONPATH=$ROOT python integrations/google_oauth.py
-env PYTHONPATH=$ROOT BUS_URL=http://127.0.0.1:7088 python orchestrator.py boot &
+env PYTHONPATH=$ROOT BUS_URL=http://127.0.0.1:7088 AGENT_SERVER_SECRET=${AGENT_SERVER_SECRET} python orchestrator.py boot &
 PID=$!
-if [ "$1" != "-NoTUI" ]; then PYTHONPATH=$ROOT python orchestrator.py shell; fi
+if [ "$1" != "-NoTUI" ]; then AGENT_SERVER_SECRET=${AGENT_SERVER_SECRET} PYTHONPATH=$ROOT python orchestrator.py shell; fi
 wait $PID


### PR DESCRIPTION
## Summary
- validate `Authorization` header against `AGENT_SERVER_SECRET`
- reject unauthorized requests and log to knowledge base
- pass secret through deployment scripts and sample env

## Testing
- `python -m py_compile agent_server.py`
- `bash -n sesamawake.sh`
- `PYTHONPATH=. python stub middleware test`

------
https://chatgpt.com/codex/tasks/task_e_68a0a78f1fa08322a2e0b417b1a9fcce