### PR TITLE
docs: expand security guidance and auth flows

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -59,6 +59,17 @@ Admin TUI commands:
 - PowerShell allow/deny lists for command execution
 - CEO policy engine governs agent permissions
 - Bearer token auth for bus and agent servers
+  - Set `BUS_TOKEN` and `AGENT_SHARED_SECRET` in the environment
+  - Bus example:
+    ```bash
+    curl "$BUS_URL/health" -H "Authorization: Bearer $BUS_TOKEN"
+    ```
+  - Agent example:
+    ```bash
+    curl http://127.0.0.1:8000/health -H "Authorization: Bearer $AGENT_SHARED_SECRET"
+    ```
+  - Unauthorized requests are logged to the knowledge base
+  - Use long, random tokens and rotate them regularly
 
 ## Development & Testing
 Run linting and tests before committing:

--- a/agent_server.py
+++ b/agent_server.py
@@ -1,3 +1,11 @@
+"""Agent API server secured by a shared secret and bus token.
+
+Incoming HTTP requests are validated against ``AGENT_SHARED_SECRET`` via
+middleware checking the ``Authorization: Bearer`` header.
+When configured, the service authenticates to the message bus with ``BUS_TOKEN``
+so only trusted agents can publish or subscribe.
+"""
+
 import os
 import threading
 from pathlib import Path

--- a/bus_server.py
+++ b/bus_server.py
@@ -1,3 +1,10 @@
+"""FastAPI message bus with bearer token authentication.
+
+All requests must supply an ``Authorization: Bearer`` header whose token
+matches the ``BUS_TOKEN`` environment variable. Requests with an invalid
+token return ``401 Unauthorized``.
+"""
+
 import os
 from fastapi import FastAPI, Depends, HTTPException, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,18 @@
+# Security Guide
+
+## Authentication
+- **Message bus**: protect `/publish` and `/get` with a bearer token set in the `BUS_TOKEN` env var.
+  - Example: `curl "$BUS_URL/health" -H "Authorization: Bearer $BUS_TOKEN"`
+- **Agent server**: require `AGENT_SHARED_SECRET` for all requests.
+  - Example: `curl http://127.0.0.1:8000/health -H "Authorization: Bearer $AGENT_SHARED_SECRET"`
+- Store secrets in environment variables and rotate them regularly.
+
+## Authorization
+- The CEO policy engine (`admin_policy.py`) enforces high-level rules over agent actions.
+- PowerShell allow/deny lists restrict which commands can be executed by scripts.
+
+## Hardening
+- Run services behind TLS and limit network exposure.
+- Use long, random tokens and change them periodically.
+- Log and monitor `auth_failure` events from the knowledge base.
+- Keep dependencies patched and apply the principle of least privilege for file and process permissions.


### PR DESCRIPTION
## Summary
- expand `README.txt` Security section with environment tokens and curl examples
- document bus and agent auth flows via module-level docstrings
- add `docs/security.md` covering authentication, authorization and hardening guidance

## Testing
- `flake8` *(fails: existing style errors in repository)*
- `flake8 bus_server.py agent_server.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a0b420bef483228983edd066e8c0fe