### PR TITLE
chore: ignore tar archives and document release packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ reports/
 runs/
 assets/badges/*.png
 assets/frames/*.png
+
+*.tar.gz

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,11 @@
+# Release Packaging
+
+Use the packaging script to build a source archive:
+
+```bash
+./scripts/create_tarball.sh
+```
+
+This produces `Cloudhabil_CLI_patch.tar.gz` in the project root. The archive is excluded from version control; regenerate it as needed rather than committing it.
+
+For pre-built binaries, download releases from the project's GitHub Releases page.

--- a/scripts/create_tarball.sh
+++ b/scripts/create_tarball.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT="$ROOT_DIR/Cloudhabil_CLI_patch.tar.gz"
+
+# Create a source archive excluding VCS and other ignored files
+tar --exclude-vcs --exclude-from="$ROOT_DIR/.gitignore" -czf "$OUTPUT" -C "$ROOT_DIR" .
+
+echo "Created $OUTPUT"


### PR DESCRIPTION
## Summary
- remove prebuilt tarball and ignore future `.tar.gz` archives
- add `create_tarball.sh` script and document release packaging

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0bda6b6048322bc56571305334e9c